### PR TITLE
Codebase viewer responsiveness

### DIFF
--- a/src/app/zip-file-explorer/zip/zip.component.html
+++ b/src/app/zip-file-explorer/zip/zip.component.html
@@ -1,10 +1,21 @@
 <div class="background">
-  <div class="header"><span> Code Base Viewer</span></div>
+  <div class="header">Code Base Viewer</div>
     <div class="btn-container">
-      <button *ngFor="let link of availableUrls" class="btn-open btn-side"(click)='sendRequest(link)'>🗁{{safeTitle(link)}}</button>
-      <label class="fileContainer" title="Open Local File">🗁 <span class="label">Open local file.</span><input #fileOpener type="file" (change)='openData(fileOpener.files[0])'></label>
-      <button class="btn-home btn-side"(click)='goBack()'>⌂ <span class="label">Home</span></button>
-      <h4 class="display-text"> &#x25b7; Explorer</h4>
+      <button *ngFor="let link of availableUrls" class="btn-open btn-side"(click)='sendRequest(link)'>
+        <div class="btn-img">🗁</div>
+        <!-- The button text for these buttons require further guidance from higher. -->
+        <div class="btn-txt">{{title}}</div>
+      </button>
+      <label class="fileContainer" title="Open Local File">
+        <div class="btn-img">🗁</div>
+        <div class="btn-txt">Local</div>
+        <input #fileOpener type="file" (change)='openData(fileOpener.files[0])'>
+      </label>
+      <button class="btn-home btn-side"(click)='goBack()'>
+        <div class="btn-img">⌂</div>
+        <div class="btn-txt">Home</div>
+      </button>
+      <h4 class="display-text">&nbsp;&#x25b7; Explorer</h4>
       <div>
       <p *ngFor="let help of RenderFile" [class.selected_p]="SelectedFile === help" (click)="openRenderFile(help)">{{help.fileName}}</p>
     </div>

--- a/src/app/zip-file-explorer/zip/zip.component.html
+++ b/src/app/zip-file-explorer/zip/zip.component.html
@@ -1,16 +1,12 @@
 <div class="background">
   <div class="header"><span> Code Base Viewer</span></div>
     <div class="btn-container">
-      <label *ngFor="let link of availableUrls" [for]="safeTitle(link)">{{safeTitle(link)}}</label>
-      <button *ngFor="let link of availableUrls" class="btn-open btn-side"(click)='sendRequest(link)' [id]="safeTitle(link)">🗁</button>
-      <label class="fileContainer">🗁
-        <input #fileOpener type="file" class="" (change)='openData(fileOpener.files[0])' >
-        </label>
-      <button class="btn-home btn-side"(click)='goBack()'>⌂</button>
-    
+      <button *ngFor="let link of availableUrls" class="btn-open btn-side"(click)='sendRequest(link)'>🗁{{safeTitle(link)}}</button>
+      <label class="fileContainer" title="Open Local File">🗁 <span class="label">Open local file.</span><input #fileOpener type="file" (change)='openData(fileOpener.files[0])'></label>
+      <button class="btn-home btn-side"(click)='goBack()'>⌂ <span class="label">Home</span></button>
       <h4 class="display-text"> &#x25b7; Explorer</h4>
       <div>
-      <p *ngFor="let help of RenderFile" [class.selected_p]="SelectedFile === help"  (click)="openRenderFile(help)">{{help.fileName}}</p>
+      <p *ngFor="let help of RenderFile" [class.selected_p]="SelectedFile === help" (click)="openRenderFile(help)">{{help.fileName}}</p>
     </div>
     </div>
   <div class="container_div">

--- a/src/app/zip-file-explorer/zip/zip.component.html
+++ b/src/app/zip-file-explorer/zip/zip.component.html
@@ -15,7 +15,7 @@
         <div class="btn-img">⌂</div>
         <div class="btn-txt">Home</div>
       </button>
-      <h4 class="display-text">&nbsp;&#x25b7; Explorer</h4>
+      <div class="display-text">&nbsp;&#x25b7; Explorer</div>
       <div>
       <p *ngFor="let help of RenderFile" [class.selected_p]="SelectedFile === help" (click)="openRenderFile(help)">{{help.fileName}}</p>
     </div>

--- a/src/app/zip-file-explorer/zip/zip.component.scss
+++ b/src/app/zip-file-explorer/zip/zip.component.scss
@@ -252,7 +252,7 @@ textarea{
   position: relative;
   top: 0;
   left: 0;
-  width: 14vw;
+  width: 13.87vw;
   display: block;
   float: left;
   height: 80vh;
@@ -372,11 +372,14 @@ textarea{
   font-size: 1.5em;
   color: $TextImportant;
 }
-.display-text{
+::ng-deep .display-text{
   color: $TextImportant;
   background-color: $Saturation80;
   padding: 5px 0px 5px 0px;
-  font-size: 1.4vw;
+  font-size: 1.35vw;
+  max-width: 13vw;
+  max-height: 2.5vh;
+  margin-right: 0px;
 }
 
 //end of code display css

--- a/src/app/zip-file-explorer/zip/zip.component.scss
+++ b/src/app/zip-file-explorer/zip/zip.component.scss
@@ -238,7 +238,7 @@ textarea{
 .fileContainer [type=file] {
   cursor: inherit;
   display: block;
-  font-size: 2em;
+  font-size: 2vw;
   filter: alpha(opacity=0);
   height:.1px;
   width:.1px;
@@ -306,13 +306,23 @@ textarea{
   height: 1.88em;
   width: 1.88em;
   text-align: center;
+  float:left;
+  top:0;
+  clear: left;
 }
 
-.label {
-  font-size: 1vw;
-  margin-top: 0px;
-  padding-top: 0px;
+.btn-img {
+  height: 70%;
+  font-size: 2vw;
+  display: flex;
+  justify-content: center;
+}
 
+.btn-txt {
+  height: 30%;
+  font-size: 1vw;
+  display: flex;
+  justify-content: center;
 }
 
 //end of side bar css
@@ -349,17 +359,13 @@ textarea{
 }
 //header css
 .header {
- 
-  max-width: 100%;
-  background-color: rgb(233, 236, 239);
   /*
   *background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0)60%, rgba(255, 77, 246, 0.24));
-  */padding-left:10em;
-  padding-top: 2px;
-  height: 30px;
-  min-height: 30px;
-  margin: 0%;
+  */
   box-shadow: $Shadow;
+  display: flex;
+  justify-content: center;
+  font-size: 4vw;
 }
 .header > span{
   // text-shadow: 1px 0px 1px #faea07f3, -1px 0px 1px #f70cd7f3;
@@ -370,7 +376,7 @@ textarea{
   color: $TextImportant;
   background-color: $Saturation80;
   padding: 5px 0px 5px 0px;
-  word-wrap: normal;
+  font-size: 1.4vw;
 }
 
 //end of code display css

--- a/src/app/zip-file-explorer/zip/zip.component.scss
+++ b/src/app/zip-file-explorer/zip/zip.component.scss
@@ -211,7 +211,6 @@ textarea{
 //side bar css
 .fileContainer {
   overflow: hidden;
-
   border-color: rgb(165, 165, 165);
   border-style: none;
   border-width: 0px;
@@ -219,9 +218,9 @@ textarea{
   background-color:  $Saturation80;
   // border-radius: 5px;
   padding: .2em;
-  font-size: 2em;
-  height:37px;
-  width:37px;
+  font-size: 2vw;
+  height: 1.5em;
+  width: 1.5em;
   text-align: center;
   color: $TextPassive;
   float:left;
@@ -229,8 +228,6 @@ textarea{
   clear: left;
   color:rgb(31, 192, 31);
 }
-
-
 
 .fileContainer:hover{
   background-color: $Saturation100;
@@ -255,7 +252,7 @@ textarea{
   position: relative;
   top: 0;
   left: 0;
-  width: 14%;
+  width: 14vw;
   display: block;
   float: left;
   height: 80vh;
@@ -303,6 +300,19 @@ textarea{
 }
 .btn-container>div:hover{
   overflow-y:auto;
+}
+.btn-container>.btn-home {
+  font-size: 2vw;
+  height: 1.88em;
+  width: 1.88em;
+  text-align: center;
+}
+
+.label {
+  font-size: 1vw;
+  margin-top: 0px;
+  padding-top: 0px;
+
 }
 
 //end of side bar css
@@ -362,4 +372,5 @@ textarea{
   padding: 5px 0px 5px 0px;
   word-wrap: normal;
 }
+
 //end of code display css

--- a/src/app/zip-file-explorer/zip/zip.component.ts
+++ b/src/app/zip-file-explorer/zip/zip.component.ts
@@ -6,6 +6,7 @@ import * as JSZip from 'jszip';
 import { NgMetaService } from 'ngmeta';
 
 import { ProjectService } from 'src/app/core/services/project.service';
+import { Title } from '@angular/platform-browser';
 
 @Component({
   selector: 'app-zip-component',
@@ -35,6 +36,7 @@ export class ZipComponent implements OnInit {
   filepath = '';
   browserSupported = true;
   availableUrls: string [] = [];
+  title = '';
   /**
    * Constructur: Injects Http Client into the component for use of resource request
    * @param HttpClient standard angular dependency to fire http request.
@@ -98,7 +100,8 @@ Currently can open and navigate to the src directory of Angular and Java Reposit
     return testfile;
   }
   safeTitle(link: string) {
-    return link.substring(link.lastIndexOf('/') + 1);
+    this.title = link.substring(link.lastIndexOf('/') + 1);
+    return this.title;
   }
   /**
    * Zip.goBack()


### PR DESCRIPTION
The codebase viewer is now fully responsive to the screen size and has labels for the buttons in the side nav bar.  
Edit June 10, 2019 @9:38 AM: The codebase viewer now works in the normal laptop view as well.
<img width="1438" alt="Normal-laptop-view" src="https://user-images.githubusercontent.com/49167261/59199509-2083a680-8b64-11e9-9a2e-5ed52d9a908b.PNG">
<img width="571" alt="IPad-view" src="https://user-images.githubusercontent.com/49167261/59113020-46b20800-8912-11e9-96ea-fd857d4ee617.PNG">
<img width="459" alt="IPhone-5-view" src="https://user-images.githubusercontent.com/49167261/59113021-46b20800-8912-11e9-978b-b8ea5775c9df.PNG">
<img width="1104" alt="Desktop-view" src="https://user-images.githubusercontent.com/49167261/59113022-46b20800-8912-11e9-99c0-0f660b90afc1.PNG">


