### PR TITLE
Upload files logic modifications

### DIFF
--- a/src/app/project/project-submission/project-submission.component.ts
+++ b/src/app/project/project-submission/project-submission.component.ts
@@ -126,21 +126,23 @@ export class ProjectSubmissionComponent implements OnInit {
   }
 
   /**
-   * When the file input is triggered, the event is passed to this method
+   * When the file input is triggered, the event is passed to this method,
    * which uses the properties of the event to retrieve the files chosen and
-   * place them in the array corresponding to the screenShots/dataModel array of the project to be submitted
+   * places them in the array corresponding to the screenShots/dataModel array of the project to be submitted
    * 
-   * This method will now check for file size and if the file is too large, open a snackbar message and
-   * not add the file to the project
+   * This method will now check for:
+   * Upload limits: If the screenshots and data models uploaded exceed a certain amount, 
+   *    opens a snackbar message and not add the file to the project.
+   * File size: If the file is too large, opens a snackbar message, and does not the file to the project.
    *
    * @param e the event corresponding to the user choosing a file to uplodad
-   * @author Justin Kerr, Rodel Flores
+   * @author Justin Kerr, Rodel Flores (190422-Java-USF)
    */
   imagePath;
   imgURL : any;
   screenshotCap : number = 4;
   dataModelCap: number = 6;
-  fileSizeCap: number = 10;
+  fileSizeCap: number = 1000000; //1 MB
   onFileSelected(e, inputfield) {
 
     //Check for limits reached
@@ -154,16 +156,10 @@ export class ProjectSubmissionComponent implements OnInit {
       return;
     }
 
-    let reader = new FileReader();
-    reader.readAsDataURL(e.target.files[0]);
-    reader.onload = (_event) => {
-    this.screenshotPicList.push(reader.result);
-    }    
-
     for (let i = 0; i < e.target.files.length; i++) {
 
-      if (e.target.files[i].size > 1024*1000*this.fileSizeCap) { // 10 MB
-        this.snackbar.openSnackBar('File too large', 'dismiss');
+      if (e.target.files[i].size > this.fileSizeCap) {
+        this.snackbar.openSnackBar('File size exceeds 1 MB', 'dismiss');
         return;
       }
       if (inputfield === 'scs') {
@@ -172,18 +168,25 @@ export class ProjectSubmissionComponent implements OnInit {
       else if (inputfield === 'dms') this.projectToUpload.dataModel.push(e.target.files[i]);
     }
 
+    let reader = new FileReader();
+    reader.readAsDataURL(e.target.files[0]);
+    reader.onload = (_event) => {
+    this.screenshotPicList.push(reader.result);
+    }    
+
   }
 
   /**
-   * Finds the index of the file within projectToUpload that was previously uploaded to the form
-   * and removes it using a basic splice method
-   * Also removes the picture from the screenshot picture list
+   * Finds the index of the file within projectToUpload that was previously 
+   * uploaded to the form and removes it using a basic splice method.
+   * Also removes the picture from the screenshot picture list.
    * 
-   * Currently if you remove a file and try to add the same one back, it won't be added back.
-   * If you try to add another file and then retry adding the previous file, it WILL be added back.
+   * Currently, if you remove a file and sequentially try to add the same one back, it won't be added back.
+   * If you try to add another file and then retry adding the previously-deleted file, it WILL be added back.
+   * Also, if you attempt to upload the same file, it won't be added, and the system doesn't throw an error.
    *
    * @param file: the file that was uploaded to the form
-   * @author Justin Kerr
+   * @author Justin Kerr (190422-Java-USF)
    */
   removeData(file: File, inputfield) {
     let list;
@@ -209,7 +212,7 @@ export class ProjectSubmissionComponent implements OnInit {
    * All the data of the form is placed as key/value pairs into a FormData object
    * This FormData object is then sent to the project service for communication with the server
    * @author Shawn Bickel (1810-Oct08-Java-USF)
-   * @author Justin Kerr, Rodel Flores
+   * @author Justin Kerr, Rodel Flores (190422-Java-USF)
    */
   submitForm() {
     let formData = new FormData();


### PR DESCRIPTION
-Limited the upload size to 1MB, tested properly on screenshots.
-Reordered the upload files logic so that the file size logic can be checked before populating the screenshot previews. The size testing causes large images to fail, but loading a valid screenshot afterwards causes the application to upload a preview the failed image instead. This re-ordering corrects that issue.