### PR TITLE
Approve/deny pending projects and edit requests - Donald / Mikaela

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import {ProjectGridPageComponent} from './components/pages/project/project-grid-
 import { ProjectSubmissionPageComponent } from './components/pages/project-submission/project-submission-page/project-submission-page.component';
 import { ProjectEditComponent } from './components/pages/project-edit/project-edit.component';
 import { ProfileComponent } from './components/pages/user-management/profile/profile.component';
+import { ProjectsPendingApprovalPageComponent } from './components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component';
 
 const routes: Routes = [
   {path: '', redirectTo: 'projects', pathMatch: 'full'},
@@ -15,6 +16,7 @@ const routes: Routes = [
   {path: 'submitform', component: ProjectSubmissionPageComponent},
   {path: 'updateform', component: ProjectEditComponent},
   {path: 'profile', component: ProfileComponent},
+  {path: 'projects/pending', component: ProjectsPendingApprovalPageComponent},
 
   // Do not put any routes below this one!
   {path: '**', component: PageNotFoundComponent}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,6 +31,8 @@ import { CodebasePageComponent } from './components/pages/codebase-page/codebase
 import { AllUsersPageComponent } from './components/pages/user-management/all-users-page/all-users-page.component';
 import { EllipsisPipe } from './ellipsis.pipe';
 import { ProjectWelcomePageComponent } from './components/pages/project/project-welcome-page/project-welcome-page.component';
+import { ProjectsPendingApprovalPageComponent } from './components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component';
+import { PendingProjectsTableComponent } from './components/pages/project-approval/pending-projects-table/pending-projects-table.component';
 
 @NgModule({
   declarations: [
@@ -53,7 +55,9 @@ import { ProjectWelcomePageComponent } from './components/pages/project/project-
     CodebasePageComponent,
     AllUsersPageComponent,
     EllipsisPipe,
-    ProjectWelcomePageComponent
+    ProjectWelcomePageComponent,
+    ProjectsPendingApprovalPageComponent,
+    PendingProjectsTableComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,8 @@ import { EllipsisPipe } from './ellipsis.pipe';
 import { ProjectWelcomePageComponent } from './components/pages/project/project-welcome-page/project-welcome-page.component';
 import { ProjectsPendingApprovalPageComponent } from './components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component';
 import { PendingProjectsTableComponent } from './components/pages/project-approval/pending-projects-table/pending-projects-table.component';
+import { SelectedProjectViewerComponent } from './components/pages/project-approval/selected-project-viewer/selected-project-viewer.component';
+import { PendingEditRequestsTableComponent } from './components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component';
 
 @NgModule({
   declarations: [
@@ -57,7 +59,9 @@ import { PendingProjectsTableComponent } from './components/pages/project-approv
     EllipsisPipe,
     ProjectWelcomePageComponent,
     ProjectsPendingApprovalPageComponent,
-    PendingProjectsTableComponent
+    PendingProjectsTableComponent,
+    SelectedProjectViewerComponent,
+    PendingEditRequestsTableComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/components/HUD/nav-menu/nav-menu.component.html
+++ b/src/app/components/HUD/nav-menu/nav-menu.component.html
@@ -16,6 +16,9 @@
           <a (click)="getProjects('all')" mat-button>All Projects</a>
         </mat-expansion-panel>
 
+        <!-- only show if user is admin! -->
+        <a *ngIf="user.role === 'ROLE_ADMIN'" (click)="goToPendingProjects()" mat-button>View Pending Projects</a>
+
         <a (click)="goToSubmit()" mat-button>Submit a Project</a>
 
         <a mat-button (click)="goToProfile()">Profile</a>

--- a/src/app/components/HUD/nav-menu/nav-menu.component.ts
+++ b/src/app/components/HUD/nav-menu/nav-menu.component.ts
@@ -72,7 +72,7 @@ export class NavMenuComponent implements OnInit {
 
   /**
    * Function that:
-   * Navigates to the pending-projects-edit-requests component.
+   * Navigates to the projects-pending-approval-page component.
    */
   goToPendingProjects() {
     this.router.navigate(['projects/pending']);

--- a/src/app/components/HUD/nav-menu/nav-menu.component.ts
+++ b/src/app/components/HUD/nav-menu/nav-menu.component.ts
@@ -72,6 +72,14 @@ export class NavMenuComponent implements OnInit {
 
   /**
    * Function that:
+   * Navigates to the pending-projects-edit-requests component.
+   */
+  goToPendingProjects() {
+    this.router.navigate(['projects/pending']);
+  }
+
+  /**
+   * Function that:
    * Navigates to the profile component.
    */
   goToProfile() {

--- a/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.html
+++ b/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.html
@@ -1,5 +1,6 @@
-<h1>Pending Projects</h1>
+<h1>Edit Requests</h1>
 <div class="mat-elevation-z8">
+
   <mat-table [dataSource]="dataSource" matSort>
     <!-- Column -->
     <ng-container matColumnDef="Trainer">

--- a/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.html
+++ b/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.html
@@ -1,6 +1,5 @@
 <h1>Edit Requests</h1>
 <div class="mat-elevation-z8">
-
   <mat-table [dataSource]="dataSource" matSort>
     <!-- Column -->
     <ng-container matColumnDef="Trainer">
@@ -21,7 +20,7 @@
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row (click)="onSwapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <mat-row id="swapProjectRow" (click)="onSwapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
   </mat-table>
   <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
 

--- a/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.html
+++ b/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.html
@@ -23,5 +23,4 @@
     <mat-row id="swapProjectRow" (click)="onSwapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
   </mat-table>
   <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
-
 </div>

--- a/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.spec.ts
+++ b/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PendingEditRequestsTableComponent } from './pending-edit-requests-table.component';
+
+describe('PendingEditRequestsTableComponent', () => {
+  let component: PendingEditRequestsTableComponent;
+  let fixture: ComponentFixture<PendingEditRequestsTableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PendingEditRequestsTableComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PendingEditRequestsTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.spec.ts
+++ b/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.spec.ts
@@ -1,10 +1,13 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PendingEditRequestsTableComponent } from './pending-edit-requests-table.component';
+import { Project } from 'src/app/models/Project';
 
 describe('PendingEditRequestsTableComponent', () => {
   let component: PendingEditRequestsTableComponent;
   let fixture: ComponentFixture<PendingEditRequestsTableComponent>;
+  let row: Project;
+
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -21,5 +24,15 @@ describe('PendingEditRequestsTableComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should emit on click', () => {
+    spyOn(component.swapProject, 'emit');
+    const nativeElement = fixture.nativeElement;
+    const matRow = nativeElement.querySelector('mat-row');
+    matRow.dispatchElement(new Event('click'));
+    fixture.detectChanges();
+
+    expect(component.swapProject.emit).toHaveBeenCalledWith(this.row);
   });
 });

--- a/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.spec.ts
+++ b/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.spec.ts
@@ -1,19 +1,28 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { PendingEditRequestsTableComponent } from './pending-edit-requests-table.component';
-import { Project } from 'src/app/models/Project';
+import { MatTableModule, MatPaginatorModule, MatListModule, MatGridListModule } from '@angular/material';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('PendingEditRequestsTableComponent', () => {
   let component: PendingEditRequestsTableComponent;
   let fixture: ComponentFixture<PendingEditRequestsTableComponent>;
-  let row: Project;
-
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PendingEditRequestsTableComponent ]
+      imports: [
+        MatTableModule,
+        MatPaginatorModule,
+        MatListModule,
+        MatGridListModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        NoopAnimationsModule
+      ],
+      declarations: [PendingEditRequestsTableComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -26,13 +35,13 @@ describe('PendingEditRequestsTableComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should emit on click', () => {
-    spyOn(component.swapProject, 'emit');
-    const nativeElement = fixture.nativeElement;
-    const matRow = nativeElement.querySelector('mat-row');
-    matRow.dispatchElement(new Event('click'));
+  it('should test the pending edit request table headers', () => {
     fixture.detectChanges();
+    const matHeaderCell = fixture.nativeElement.querySelectorAll('mat-header-cell');
+    expect(matHeaderCell.length).toBe(3);
 
-    expect(component.swapProject.emit).toHaveBeenCalledWith(this.row);
+    expect(matHeaderCell[0].innerHTML).toBe(' Trainer\'s Name ');
+    expect(matHeaderCell[1].innerHTML).toBe(' Project\'s Name ');
+    expect(matHeaderCell[2].innerHTML).toBe(' Status of Request ');
   });
 });

--- a/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.ts
+++ b/src/app/components/pages/project-approval/pending-edit-requests-table/pending-edit-requests-table.component.ts
@@ -1,14 +1,14 @@
-import { Component, OnInit, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter  } from '@angular/core';
 import { ProjectService } from 'src/app/services/project.service';
 import { Router } from '@angular/router';
 import { Project } from 'src/app/models/Project';
 
 @Component({
-  selector: 'app-pending-projects-table',
-  templateUrl: './pending-projects-table.component.html',
-  styleUrls: ['./pending-projects-table.component.scss']
+  selector: 'app-pending-edit-requests-table',
+  templateUrl: './pending-edit-requests-table.component.html',
+  styleUrls: ['./pending-edit-requests-table.component.scss']
 })
-export class PendingProjectsTableComponent implements OnInit {
+export class PendingEditRequestsTableComponent implements OnInit {
 
   @Output() swapProject = new EventEmitter<{row: any}>();
 
@@ -21,7 +21,7 @@ export class PendingProjectsTableComponent implements OnInit {
 
   ngOnInit() {
     this.selected = false;
-    this.projectService.getProjectsByStatus('Pending').subscribe(response => {
+    this.projectService.getProjectsByStatus('PendingEdit').subscribe(response => {
       this.dataSource = response;
     });
   }

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
@@ -23,8 +23,8 @@
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row (click)="swapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <mat-row (click)="onSwapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
   </mat-table>
   <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
-  <!-- <app-project-approval *ngIf="selected"></app-project-approval> -->
+  
 </div>

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
@@ -1,0 +1,30 @@
+<mat-form-field>
+  <input matInput (keyup)="applyFilter($event.target.value)" placeholder="Search">
+</mat-form-field>
+<div class="mat-elevation-z8">
+
+  <mat-table [dataSource]="dataSource" matSort>
+    <!-- Column -->
+    <ng-container matColumnDef="Trainer">
+      <mat-header-cell *matHeaderCellDef mat-sort-header> Trainer's Name </mat-header-cell>
+      <mat-cell *matCellDef="let element"> {{element.trainer}} </mat-cell>
+    </ng-container>
+
+    <!-- Column -->
+    <ng-container matColumnDef="Project">
+      <mat-header-cell *matHeaderCellDef mat-sort-header> Project's Name </mat-header-cell>
+      <mat-cell *matCellDef="let element"> {{element.name}} </mat-cell>
+    </ng-container>
+
+    <!-- Column -->
+    <ng-container matColumnDef="Status of Request">
+      <mat-header-cell *matHeaderCellDef mat-sort-header> Status of Request </mat-header-cell>
+      <mat-cell *matCellDef="let element"> {{element.status}} </mat-cell>
+    </ng-container>
+
+    <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+    <mat-row (click)="swapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
+  </mat-table>
+  <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+  <!-- <app-project-approval *ngIf="selected"></app-project-approval> -->
+</div>

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
@@ -20,7 +20,7 @@
     </ng-container>
 
     <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-    <mat-row (click)="onSwapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    <mat-row id="swapProjectRow" (click)="onSwapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
   </mat-table>
   <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
 

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.html
@@ -23,5 +23,4 @@
     <mat-row id="swapProjectRow" (click)="onSwapProject(row)" *matRowDef="let row; columns: displayedColumns;"></mat-row>
   </mat-table>
   <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
-
 </div>

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.spec.ts
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PendingProjectsTableComponent } from './pending-projects-table.component';
+
+describe('PendingProjectsTableComponent', () => {
+  let component: PendingProjectsTableComponent;
+  let fixture: ComponentFixture<PendingProjectsTableComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PendingProjectsTableComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PendingProjectsTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.spec.ts
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { PendingProjectsTableComponent } from './pending-projects-table.component';
+import { MatTableModule, MatPaginatorModule, MatListModule, MatGridListModule } from '@angular/material';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('PendingProjectsTableComponent', () => {
   let component: PendingProjectsTableComponent;
@@ -8,9 +11,18 @@ describe('PendingProjectsTableComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ PendingProjectsTableComponent ]
+      imports: [
+        MatTableModule,
+        MatPaginatorModule,
+        MatListModule,
+        MatGridListModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        NoopAnimationsModule
+      ],
+      declarations: [PendingProjectsTableComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -22,4 +34,15 @@ describe('PendingProjectsTableComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should test the pending projects table headers', () => {
+    fixture.detectChanges();
+    const matHeaderCell = fixture.nativeElement.querySelectorAll('mat-header-cell');
+    expect(matHeaderCell.length).toBe(3);
+
+    expect(matHeaderCell[0].innerHTML).toBe(' Trainer\'s Name ');
+    expect(matHeaderCell[1].innerHTML).toBe(' Project\'s Name ');
+    expect(matHeaderCell[2].innerHTML).toBe(' Status of Request ');
+  });
+
 });

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.ts
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { ProjectService } from 'src/app/services/project.service';
+import { Router } from '@angular/router';
+import { Project } from 'src/app/models/Project';
+
+@Component({
+  selector: 'app-pending-projects-table',
+  templateUrl: './pending-projects-table.component.html',
+  styleUrls: ['./pending-projects-table.component.scss']
+})
+export class PendingProjectsTableComponent implements OnInit {
+
+  dataSource: Project[];
+  selected: boolean;
+  displayedColumns: string[] = ['Trainer', 'Project', 'Status of Request'];
+  displayedColumnsData: string[] = ['trainer', 'name', 'status'];
+
+  constructor(private router: Router, private projectService: ProjectService) { }
+
+  ngOnInit() {
+    this.selected = false;
+    this.projectService.getProjectsByStatus('Pending').subscribe(response => {
+      this.dataSource = response;
+    });
+  }
+
+  swapProject(row): void {
+    this.selected = true;
+    console.log(this.selected);
+    this.projectService.CurrentProject$.next(row);
+  }
+
+}

--- a/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.ts
+++ b/src/app/components/pages/project-approval/pending-projects-table/pending-projects-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { ProjectService } from 'src/app/services/project.service';
 import { Router } from '@angular/router';
 import { Project } from 'src/app/models/Project';
@@ -9,6 +9,8 @@ import { Project } from 'src/app/models/Project';
   styleUrls: ['./pending-projects-table.component.scss']
 })
 export class PendingProjectsTableComponent implements OnInit {
+
+  @Output() swapProject = new EventEmitter<{row: any}>();
 
   dataSource: Project[];
   selected: boolean;
@@ -24,10 +26,8 @@ export class PendingProjectsTableComponent implements OnInit {
     });
   }
 
-  swapProject(row): void {
-    this.selected = true;
-    console.log(this.selected);
-    this.projectService.CurrentProject$.next(row);
+  onSwapProject(row): void {
+    this.swapProject.emit({row: row});
   }
 
 }

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
@@ -9,6 +9,6 @@
       </mat-grid-tile>
     </mat-grid-list>
     <!--project viewer -->
-    <app-selected-project-viewer *ngIf="selected"></app-selected-project-viewer>
+    <app-selected-project-viewer class="project-viewer" *ngIf="selected"></app-selected-project-viewer>
   </mat-card-content>
 </mat-card>

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
@@ -1,12 +1,14 @@
 <mat-card>
   <mat-card-content>
-    <!-- pending projects table -->
-    <app-pending-projects-table (swapProject)="onSwapProject($event)" ></app-pending-projects-table>
-
-    <!-- pending edit requests table -->
-
-
-    <!-- #TODO project viewer -->
-    <!-- #TODO <app-project-approval *ngIf="selected"></app-project-approval> -->
+    <mat-grid-list cols="2" rowHeight="2:1">
+      <mat-grid-tile id="pending_projects_table">
+          <app-pending-projects-table (swapProject)="onSwapProject($event)"></app-pending-projects-table>
+      </mat-grid-tile>
+      <mat-grid-tile id="pending_edit_requests_table">
+          <app-pending-edit-requests-table (swapProject)="onSwapProject($event)"></app-pending-edit-requests-table>
+      </mat-grid-tile>
+    </mat-grid-list>
+    <!--project viewer -->
+    <app-selected-project-viewer *ngIf="selected"></app-selected-project-viewer>
   </mat-card-content>
 </mat-card>

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
@@ -1,6 +1,12 @@
 <mat-card>
   <mat-card-content>
     <!-- pending projects table -->
-    <app-pending-projects-table></app-pending-projects-table>
+    <app-pending-projects-table (swapProject)="onSwapProject($event)" ></app-pending-projects-table>
+
+    <!-- pending edit requests table -->
+
+
+    <!-- #TODO project viewer -->
+    <!-- #TODO <app-project-approval *ngIf="selected"></app-project-approval> -->
   </mat-card-content>
 </mat-card>

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.html
@@ -1,0 +1,6 @@
+<mat-card>
+  <mat-card-content>
+    <!-- pending projects table -->
+    <app-pending-projects-table></app-pending-projects-table>
+  </mat-card-content>
+</mat-card>

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.scss
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.scss
@@ -1,0 +1,4 @@
+mat-card {
+    width: 90vw;
+    margin: 1% auto;
+}

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.scss
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.scss
@@ -2,3 +2,4 @@ mat-card {
     width: 90vw;
     margin: 1% auto;
 }
+

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.spec.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ProjectsPendingApprovalPageComponent } from './projects-pending-approval-page.component';
+
+describe('ProjectsPendingApprovalPageComponent', () => {
+  let component: ProjectsPendingApprovalPageComponent;
+  let fixture: ComponentFixture<ProjectsPendingApprovalPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ProjectsPendingApprovalPageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProjectsPendingApprovalPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.spec.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.spec.ts
@@ -1,6 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { ProjectsPendingApprovalPageComponent } from './projects-pending-approval-page.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { MatTableModule, MatPaginatorModule, MatListModule, MatGridListModule } from '@angular/material';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 
 describe('ProjectsPendingApprovalPageComponent', () => {
   let component: ProjectsPendingApprovalPageComponent;
@@ -8,9 +13,18 @@ describe('ProjectsPendingApprovalPageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ProjectsPendingApprovalPageComponent ]
+      imports: [
+        MatTableModule,
+        MatPaginatorModule,
+        MatListModule,
+        MatGridListModule,
+        RouterTestingModule,
+        HttpClientTestingModule,
+        NoopAnimationsModule ],
+      declarations: [ProjectsPendingApprovalPageComponent],
+      schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
@@ -22,4 +36,9 @@ describe('ProjectsPendingApprovalPageComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should NOT show project viewer if selected is false', () => {
+    expect(fixture.debugElement.query(By.css('.project-viewer'))).toBeNull();
+  });
+
 });

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.spec.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.spec.ts
@@ -20,7 +20,8 @@ describe('ProjectsPendingApprovalPageComponent', () => {
         MatGridListModule,
         RouterTestingModule,
         HttpClientTestingModule,
-        NoopAnimationsModule ],
+        NoopAnimationsModule
+      ],
       declarations: [ProjectsPendingApprovalPageComponent],
       schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
     })

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-projects-pending-approval-page',
+  templateUrl: './projects-pending-approval-page.component.html',
+  styleUrls: ['./projects-pending-approval-page.component.scss']
+})
+export class ProjectsPendingApprovalPageComponent implements OnInit {
+
+
+  constructor() {
+  }
+
+  ngOnInit() {
+
+  }
+
+}

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
@@ -8,7 +8,7 @@ import { ProjectService } from 'src/app/services/project.service';
 })
 export class ProjectsPendingApprovalPageComponent implements OnInit {
 
-  selected: boolean;
+  selected = false;
 
   constructor(private projectService: ProjectService) {
   }

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
@@ -14,7 +14,6 @@ export class ProjectsPendingApprovalPageComponent implements OnInit {
   }
 
   ngOnInit() {
-
   }
 
   onSwapProject(row): void {

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ProjectService } from 'src/app/services/project.service';
 
 @Component({
   selector: 'app-projects-pending-approval-page',
@@ -7,12 +8,19 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ProjectsPendingApprovalPageComponent implements OnInit {
 
+  selected: boolean;
 
-  constructor() {
+  constructor(private projectService: ProjectService) {
   }
 
   ngOnInit() {
 
+  }
+
+  onSwapProject(row): void {
+    this.selected = true;
+    console.log(this.selected);
+    this.projectService.CurrentProject$.next(row);
   }
 
 }

--- a/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
+++ b/src/app/components/pages/project-approval/projects-pending-approval-page/projects-pending-approval-page.component.ts
@@ -19,7 +19,6 @@ export class ProjectsPendingApprovalPageComponent implements OnInit {
 
   onSwapProject(row): void {
     this.selected = true;
-    console.log(this.selected);
     this.projectService.CurrentProject$.next(row);
   }
 

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.html
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.html
@@ -1,0 +1,23 @@
+<mat-card>
+  <mat-card-content>
+    <div id="view-projects-grid">
+      <div id="project-title">
+        <h1 *ngIf="project">{{ project.name }}</h1>
+        <h1 *ngIf="!project">Project Viewer</h1>
+        <div>
+          <button mat-flat-button color="accent" (click)="approveProject()">Approve Project</button>
+          <button mat-flat-button color="accent" (click)="denyProject()">Deny Project</button>
+        </div>
+      </div>
+      <div id="project-info">
+        <app-project-info></app-project-info>
+      </div>
+      <div id="carousel-window">
+        <app-ngx-carousel></app-ngx-carousel>
+      </div>
+      <div id="project-description">
+        <app-project-description></app-project-description>
+      </div>
+    </div>
+  </mat-card-content>
+</mat-card>

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.html
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.html
@@ -4,8 +4,8 @@
       <div id="project-title">
         <h1>{{ project.name }}</h1>
         <div>
-          <button mat-flat-button color="accent" (click)="approveProject()">Approve Project</button>
-          <button mat-flat-button color="accent" (click)="denyProject()">Deny Project</button>
+          <button id="approve-project-btn" mat-flat-button color="accent" (click)="approveProject()">Approve Project</button>
+          <button id="deny-project-btn" mat-flat-button color="accent" (click)="denyProject()">Deny Project</button>
         </div>
       </div>
       <div id="project-info">

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.html
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.html
@@ -2,8 +2,7 @@
   <mat-card-content>
     <div id="view-projects-grid">
       <div id="project-title">
-        <h1 *ngIf="project">{{ project.name }}</h1>
-        <h1 *ngIf="!project">Project Viewer</h1>
+        <h1>{{ project.name }}</h1>
         <div>
           <button mat-flat-button color="accent" (click)="approveProject()">Approve Project</button>
           <button mat-flat-button color="accent" (click)="denyProject()">Deny Project</button>

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.scss
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.scss
@@ -1,0 +1,136 @@
+
+/*
+    Please don't use Bootstrap! Angular Material
+    and Flexbox are so much better! Once you try
+    it, you won't go back.
+     Angular Material documentation:     https://material.angular.io/
+    Excellent, quick Material tutorials:     https://youtu.be/bV8emCBmFHk
+    Flexbox tutorial:     https://www.w3schools.com/css/css3_flexbox.asp
+    20-minute SCSS tutorial:     https://youtu.be/Zz6eOVaaelI
+    Scaling apps in Angular:     https://youtu.be/Bhd2ayEE9mg
+*/
+/*
+    @import src/variables.scss relative to this file
+    in order to use the global SCSS variables within
+    this file. (Don't include the underscore in
+    _variables.scss when importing. If you want to
+    know why: http://alistapart.com/article/getting-started-with-sass/)
+     Open the _variables.scss file in a new tab so you
+    can use and make SCSS variables and make everyone's
+    lives easier.
+*/
+@import '../../../../../variables';
+
+ #projects-tabs {
+    flex-direction: row;
+}
+
+ app-project-list {
+    flex-basis: 200px;
+    flex-grow: 1;
+}
+
+ :host ::ng-deep h2 {
+    padding-bottom: 5px;
+    margin: 10px 0;
+    border-bottom: 3px solid $rev-orange-main;
+}
+
+ #project-title {
+    grid-area: title;
+    margin-left: 7px;
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+    justify-content: space-between;
+    h1 {
+        font-size: 60px;
+    }
+    button {
+        margin: 10px;
+    }
+}
+
+ #project-info {
+    grid-area: info;
+    width: 100%;
+    padding: $section-padding;
+}
+
+ #carousel-window {
+    grid-area: carousel;
+    height: 100%;
+    width: 100%;
+    padding: $section-padding;
+}
+
+ #project-description {
+    grid-area: description;
+    min-height: 30vh;
+    padding: $section-padding;
+}
+
+ #search-projects {
+    flex-basis: 150px;
+    flex-grow: 1;
+    max-height: 45px;
+}
+
+ mat-card {
+    width: 75vw;
+    margin: 1% auto;
+}
+
+ #view-projects-grid {
+    display: grid;
+  grid-template:
+        'tabs'
+        'title'
+        'carousel'
+        'info'
+        'description';
+    grid-template-columns: 100%;
+    grid-gap: 0;
+    margin: auto;
+    width:75%;
+}
+
+ input::placeholder {
+    font-size: 18px;
+}
+
+ :host ::ng-deep mat-expansion-panel {
+    padding: 0;
+    -webkit-box-shadow: 0 0 0 rgba(0,0,0,0) !important;
+            box-shadow: 0 0 0 rgba(0,0,0,0) !important;
+    width: 100%;
+    margin: auto;
+}
+
+ :host ::ng-deep #view-project-list.mat-expanded {
+    border-bottom: 2px solid $rev-orange-main;
+    border-radius: 0;
+}
+
+ @media screen and (min-width: $all-projects-breakpoint) {
+    #view-projects-grid {
+      grid-template:
+        'tabs title title'
+        'tabs info carousel'
+        'tabs description description';
+        grid-template-columns: 0% 50% 50%;
+    }
+
+     #projects-tabs {
+        display: block;
+        grid-area: tabs;
+        justify-content: start;
+        flex-direction: column;
+        padding: $section-padding;
+        padding-right: 0;
+    }
+
+     #search-projects {
+        width: 90%;
+    }
+}

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.spec.ts
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SelectedProjectViewerComponent } from './selected-project-viewer.component';
+
+describe('SelectedProjectViewerComponent', () => {
+  let component: SelectedProjectViewerComponent;
+  let fixture: ComponentFixture<SelectedProjectViewerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SelectedProjectViewerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SelectedProjectViewerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.spec.ts
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.spec.ts
@@ -1,6 +1,9 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SelectedProjectViewerComponent } from './selected-project-viewer.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 describe('SelectedProjectViewerComponent', () => {
   let component: SelectedProjectViewerComponent;
@@ -8,18 +11,48 @@ describe('SelectedProjectViewerComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SelectedProjectViewerComponent ]
+      imports: [
+        RouterTestingModule,
+        HttpClientTestingModule,
+        NoopAnimationsModule
+      ],
+      declarations: [SelectedProjectViewerComponent],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SelectedProjectViewerComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should call approveProject Method', async(() => {
+    spyOn(component, 'approveProject');
+
+    const button = fixture.debugElement.nativeElement.querySelector('#approve-project-btn');
+    button.click();
+
+    fixture.whenStable().then(() => {
+      expect(component.approveProject).toHaveBeenCalled();
+    });
+
+  }));
+
+  it('should call denyProject Method', async(() => {
+    spyOn(component, 'denyProject');
+
+    const button = fixture.debugElement.nativeElement.querySelector('#deny-project-btn');
+    button.click();
+
+    fixture.whenStable().then(() => {
+      expect(component.denyProject).toHaveBeenCalled();
+    });
+
+  }));
+
 });

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.ts
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.ts
@@ -31,25 +31,12 @@ export class SelectedProjectViewerComponent implements OnInit {
   approveProject() {
     this.project.status = 'Approved';
     this.projectService.updateProject(this.project, this.project.id).subscribe(response => {
-      console.log(response);
     });
   }
 
   denyProject() {
     this.project.status = 'Denied';
     this.projectService.updateProject(this.project, this.project.id).subscribe(response => {
-      console.log(response);
     });
   }
-
-  updateProject() {
-    this.httpClient.post('', this.project).subscribe(response => {
-      if (response === true) {
-        //  dosomething
-      } else {
-        //  dosomething
-      }
-    });
-  }
-
 }

--- a/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.ts
+++ b/src/app/components/pages/project-approval/selected-project-viewer/selected-project-viewer.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import {ProjectService} from '../../../../services/project.service';
+import {Project} from '../../../../models/Project';
+import {Router} from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+
+@Component({
+  selector: 'app-selected-project-viewer',
+  templateUrl: './selected-project-viewer.component.html',
+  styleUrls: ['./selected-project-viewer.component.scss']
+})
+export class SelectedProjectViewerComponent implements OnInit {
+
+  project: Project;
+
+  constructor(
+    private projectService: ProjectService,
+    private router: Router,
+    private httpClient: HttpClient
+  ) { }
+
+  ngOnInit() {
+    this.projectService.CurrentProject$.asObservable().subscribe(
+      proj => {
+        if (proj) {
+          this.project = proj;
+        }
+      });
+  }
+
+  approveProject() {
+    this.project.status = 'Approved';
+    this.projectService.updateProject(this.project, this.project.id).subscribe(response => {
+      console.log(response);
+    });
+  }
+
+  denyProject() {
+    this.project.status = 'Denied';
+    this.projectService.updateProject(this.project, this.project.id).subscribe(response => {
+      console.log(response);
+    });
+  }
+
+  updateProject() {
+    this.httpClient.post('', this.project).subscribe(response => {
+      if (response === true) {
+        //  dosomething
+      } else {
+        //  dosomething
+      }
+    });
+  }
+
+}

--- a/src/app/misc-modules/material/material.module.ts
+++ b/src/app/misc-modules/material/material.module.ts
@@ -18,7 +18,6 @@ import {
   MatProgressSpinnerModule,
   MatStepperModule,
   MatTooltipModule,
-  //start
   MatTableModule,
   MatPaginatorModule,
   MatListModule,
@@ -43,7 +42,6 @@ const materials = [
   MatProgressSpinnerModule,
   MatStepperModule,
   MatTooltipModule,
-  //start
   MatTableModule,
   MatPaginatorModule,
   MatListModule,

--- a/src/app/misc-modules/material/material.module.ts
+++ b/src/app/misc-modules/material/material.module.ts
@@ -1,4 +1,4 @@
-import {NgModule} from '@angular/core';
+import { NgModule } from '@angular/core';
 
 import {
   MatBadgeModule,
@@ -17,7 +17,12 @@ import {
   MatToolbarModule,
   MatProgressSpinnerModule,
   MatStepperModule,
-  MatTooltipModule
+  MatTooltipModule,
+  //start
+  MatTableModule,
+  MatPaginatorModule,
+  MatListModule,
+  MatGridListModule
 } from '@angular/material';
 
 const materials = [
@@ -37,7 +42,12 @@ const materials = [
   MatSelectModule,
   MatProgressSpinnerModule,
   MatStepperModule,
-  MatTooltipModule
+  MatTooltipModule,
+  //start
+  MatTableModule,
+  MatPaginatorModule,
+  MatListModule,
+  MatGridListModule
 ];
 
 @NgModule({

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -45,6 +45,10 @@ export class ProjectService {
     return this.httpClient.get<Project[]>(environment.url + '/project/status/Approved', HTTP_OPTIONS);
   }
 
+  getProjectsByStatus(status: string): Observable<Project[]> {
+    return this.httpClient.get<Project[]>(environment.url + `/project/status/${status}`, HTTP_OPTIONS);
+  }
+
   getProjectById(id): Observable<Project> {
     return this.httpClient.get<Project>(environment.url + `/project/id/${id}`, HTTP_OPTIONS);
   }


### PR DESCRIPTION
- User Stories Completed: 
    - As an admin, I can view all pending project submission and edit requests
    - As an admin, I can approve or deny project submission and edit requests

Details:
- Added view for pending projects and edit requests
- On click, admin is able to view the project they have selected.
- Once a project approved/denied admin can visually see their selection.
- added nav-bar item that is only viewable by admin.
- added unit tests.